### PR TITLE
Migrate base image to wolfi! 🦑🐺🔒

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,12 +1,10 @@
-FROM eclipse-temurin:17.0.8_7-jre-alpine
+FROM cgr.dev/chainguard/jdk:latest
 LABEL title="Lumionous Onion" \
     version="0.0.1" \
     author="Zachary Karpinski"
 
-RUN apk update && apk upgrade
-
 # Copy project to the image
-COPY target/luminousonion-0.0.1-SNAPSHOT.jar /app/app.jar
+COPY target/luminousonion-core-0.0.1-SNAPSHOT.jar /app/app.jar
 
 # Expose the app ports
 EXPOSE 8081

--- a/core/buildAndPackage.cmd
+++ b/core/buildAndPackage.cmd
@@ -1,5 +1,5 @@
 :: Build, Test & Package the springboot project
-call mvnw.cmd clean package
+call ..\mvnw.cmd clean package
 
 :: Created docker image from the Dockerfile
 docker build -t "zkarpinski/luminous-onion:latest" .

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -156,12 +156,15 @@
 	</dependencies>
 
 	<build>
+		<finalName>luminousonion-core-${project.version}</finalName>
 		<plugins>
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
 				<version>3.1.2</version>
 				<configuration>
+					<mainClass>com.luminousonion.LuminousOnionApplication</mainClass>
+					<layout>JAR</layout>
 					<excludes>
 						<exclude>
 							<groupId>org.projectlombok</groupId>
@@ -169,6 +172,13 @@
 						</exclude>
 					</excludes>
 				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>repackage</goal>
+						</goals>
+					</execution>
+				</executions>
 			</plugin>
 			<plugin>
 				<groupId>com.github.eirslett</groupId>


### PR DESCRIPTION
Migrate base image from eclipse-temurin:17.0.8_7-jre-alpine to Chainguard's cgr.dev/chainguard/jdk:latest wolfi image!! 🦑🐺🔒